### PR TITLE
stylefix | keep program logic flow in dispatcher

### DIFF
--- a/pycor-cli
+++ b/pycor-cli
@@ -22,17 +22,19 @@
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import sys
-import traceback
-
-from pycor.loghandler import logger, logging, sh
-from pycor.optparser import optargs
-
-
 if __name__ == "__main__":
+    import sys, traceback
+    from pycor.loghandler import logger
+    from pycor.optparser import optargs
+
+    print "Container/Overlay"
+    print "leverage overlayfs under lxd containers"
+    print
+
 
     # catch debug opt
     if optargs['--debug']:
+        from pycor.loghandler import logging, sh
         debug = True
         logger.setLevel(logging.DEBUG)
         sh.setLevel(logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pylxd
-docopt
+pylxd>=2.2.4
+docopt>=0.6.2


### PR DESCRIPTION
This commit removes all program flow logic from functions in
`pycor/overlay.py`, which should have simple, single functions.

Code that influences the program flow should be in `pycor/dispatch.py`,
which can act on exceptions raised by functions it dispatched.

Should probably consider writing a contribution guide.